### PR TITLE
fix 'response' referenced before assignment

### DIFF
--- a/gen3/submission.py
+++ b/gen3/submission.py
@@ -389,6 +389,7 @@ class Gen3Submission:
                 ).text
             except requests.exceptions.ConnectionError as e:
                 results["details"].append(e.message)
+                continue
 
             # Handle the API response
             if (


### PR DESCRIPTION
### Bug Fixes
- Fix bug in "submit_file" when "response" is not defined