### PR TITLE
(Chore): Support bundle_names in bundle manifest

### DIFF
--- a/gen3/tools/indexing/manifest_columns.py
+++ b/gen3/tools/indexing/manifest_columns.py
@@ -31,7 +31,7 @@ URLS_STANDARD_KEY = "urls"
 AUTHZ_COLUMN_NAMES = ["authz"]
 AUTHZ_STANDARD_KEY = "authz"
 
-BUNDLENAME_COLUMN_NAME = ["bundle_name", "name"]
+BUNDLENAME_COLUMN_NAME = ["bundle_name", "name", "bundle_names"]
 
 IDS_COLUMN_NAME = ["ids", "bundle_ids"]
 


### PR DESCRIPTION
IDC keeps using `bundle_names` for their manifests and also might as well support this. 

### Improvements
- Support `bundle_names` in bundle manifest