### PR TITLE
fix(add-bearer-token-header) add authorization header for Bearer token

### DIFF
--- a/docs/howto/devTest.md
+++ b/docs/howto/devTest.md
@@ -1,5 +1,19 @@
 ## Dev-Test
 
+### Set up Python Virtual Environment
+
+You can set up a Python development environment with a virtual environment:
+
+```bash
+python3 -m venv py3
+```
+
+Make sure that you have the virtual environment activated:
+
+```bash
+. py3/bin/activate
+```
+
 ### Install poetry
 
 To use the latest code in this repo (or to develop new features) you can clone this repo, install `poetry`:
@@ -22,10 +36,30 @@ Local development like this:
 ```
 poetry shell
 poetry install -vv
-python -m pytest
+python3 -m pytest
 ```
 
 There are various ways to select a subset of python unit-tests - see: https://stackoverflow.com/questions/36456920/is-there-a-way-to-specify-which-pytest-tests-to-run-from-a-file
+
+### Manual Testing
+
+You can also set up credentials to submit data to the graph in your data commons.  This assumes that you can get API access by downloading your [credentials.json](https://gen3.org/resources/user/using-api/#credentials-to-send-api-requests).
+
+> Make sure that your python virtual environment and dependencies are updated.  Also, check that your credentials have appropriate permissions to make the service calls too.
+```python
+COMMONS_URL = "https://mycommons.azurefd.net"
+PROGRAM_NAME = "MyProgram"
+PROJECT_NAME = "MyProject"
+CREDENTIALS_FILE_PATH = "credentials.json"
+gen3_node_json = {
+  "projects": {"code": PROJECT_NAME},
+  "type": "core_metadata_collection",
+  "submitter_id": "core_metadata_collection_myid123456",
+}
+auth = Gen3Auth(endpoint=COMMONS_URL, refresh_file=CREDENTIALS_FILE_PATH)
+sheepdog_client = Gen3Submission(COMMONS_URL, auth)
+json_result = sheepdog_client.submit_record(PROGRAM_NAME, PROJECT_NAME, gen3_node_json)
+```
 
 ### Smoke test
 

--- a/gen3/submission.py
+++ b/gen3/submission.py
@@ -3,6 +3,7 @@ import json
 import requests
 import pandas as pd
 import os
+import logging
 
 from gen3.utils import raise_for_status
 
@@ -198,8 +199,10 @@ class Gen3Submission:
 
         """
         api_url = "{}/api/v0/submission/{}/{}".format(self._endpoint, program, project)
+        logging.info("\nUsing the Sheepdog API URL {}\n".format(api_url))
+
         output = requests.put(api_url, auth=self._auth_provider, json=json)
-        raise_for_status(output)
+        output.raise_for_status()
         return output.json()
 
     def delete_record(self, program, project, uuid):

--- a/gen3/tools/indexing/index_manifest.py
+++ b/gen3/tools/indexing/index_manifest.py
@@ -494,6 +494,7 @@ def index_object_manifest(
         auth(Gen3Auth): Gen3 auth or tuple with basic auth name and password
         replace_urls(bool): flag to indicate if replace urls or not
         manifest_file_delimiter(str): manifest's delimiter
+        output_filename(str): output file name for manifest
 
     Returns:
         files(list(dict)): list of file info
@@ -519,6 +520,8 @@ def index_object_manifest(
 
     if not commons_url.endswith(service_location):
         commons_url += "/" + service_location
+
+    logging.info("\nUsing URL {}\n".format(commons_url))
 
     indexclient = client.IndexClient(commons_url, "v0", auth=auth)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,16 @@ from cdisutilstest.code.indexd_fixture import (
 from gen3.index import Gen3Index
 from gen3.submission import Gen3Submission
 from gen3.query import Gen3Query
+from gen3.auth import Gen3Auth
 import pytest
 from drsclient.client import DrsClient
+from unittest.mock import call, MagicMock, patch
 
 
 class MockAuth:
     def __init__(self):
         self.endpoint = "https://example.commons.com"
+        self.refresh_token = {"api_key": "123"}
 
 
 @pytest.fixture
@@ -24,6 +27,17 @@ def sub():
 @pytest.fixture
 def gen3_auth():
     return MockAuth()
+
+
+@pytest.fixture
+def mock_gen3_auth():
+    mock_auth = MockAuth()
+    # patch as __init__ has method call
+    with patch("gen3.auth.endpoint_from_token") as mock_endpoint_from_token:
+        mock_endpoint_from_token().return_value = mock_auth.endpoint
+        return Gen3Auth(
+            endpoint=mock_auth.endpoint, refresh_token=mock_auth.refresh_token
+        )
 
 
 # for unittest with mock server


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

Add retry logic for refreshing tokens for Gen3Auth.

### New Features


### Breaking Changes


### Bug Fixes
* Include retry logic for caching refreshed access tokens.

### Improvements
* Added notes for Python set up and manual testing in [devTest.md](https://github.com/uc-cdis/gen3sdk-python/blob/master/docs/howto/devTest.md)
* Additional unit tests for Gen3Auth / Gen3Submission

### Dependency updates
* Include using [backoff lib](https://github.com/litl/backoff)

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->