### PR TITLE
(PXP:8581): Add apiEndpoint and other arguments to `configure`  to avoid breaking changes

### DIFF
--- a/gen3/cli/configure.py
+++ b/gen3/cli/configure.py
@@ -6,16 +6,31 @@ import gen3.configure as config_tool
 @click.command()
 @click.option("--profile", help="name of the profile to name for this credentials")
 @click.option("--cred", help="path to the credentials.json")
-def configure(profile, cred):
+@click.option(
+    "--apiendpoint", default="", help="[optional] API endpoint of the commons"
+)
+@click.option(
+    "--use-shepherd",
+    default="",
+    help="[optional] true/false -- to enable/disable the gen3Sdk to upload using the Gen3 Object Management API (if available)",
+)
+@click.option(
+    "--min-shepherd-version",
+    default="",
+    help="[optional] Specify the minimum version of the Gen3 Object Management API ",
+)
+def configure(profile, cred, apiendpoint, use_shepherd, min_shepherd_version):
     """Command to configure multiple profiles with corresponding credentials
 
-    ./gen3 configure --profile=<profile-name> --cred=<path-to-credential/cred.json>
+    ./gen3 configure --profile=<profile-name> --cred=<path-to-credential/cred.json> --apiendpoint=https://example.com --use-sheperd=<true/false> --min-shepherd-version=<version_number>
     """
 
     logging.info(f"Configuring profile [ {profile} ] with credentials at {cred}")
 
     try:
-        profile_title, new_lines = config_tool.get_profile_from_creds(profile, cred)
+        profile_title, new_lines = config_tool.get_profile_from_creds(
+            profile, cred, apiendpoint, use_shepherd, min_shepherd_version
+        )
         lines = config_tool.get_current_config_lines()
         config_tool.update_config_lines(lines, profile_title, new_lines)
     except Exception as e:

--- a/gen3/configure.py
+++ b/gen3/configure.py
@@ -29,18 +29,22 @@ import gen3.auth as auth_tool
 CONFIG_FILE_PATH = expanduser("~/.gen3/config")
 
 
-def get_profile_from_creds(profile, cred):
+def get_profile_from_creds(
+    profile, cred, api_endpoint="", use_sheperd="", min_sheperd_version=""
+):
     with open(expanduser(cred)) as f:
         creds_from_json = json.load(f)
         credentials = OrderedDict()
         credentials["key_id"] = creds_from_json["key_id"]
         credentials["api_key"] = creds_from_json["api_key"]
-        credentials["api_endpoint"] = auth_tool.endpoint_from_token(
-            credentials["api_key"]
+        credentials["api_endpoint"] = (
+            api_endpoint
+            if api_endpoint != ""
+            else auth_tool.endpoint_from_token(credentials["api_key"])
         )
         credentials["access_key"] = auth_tool.get_access_token_with_key(credentials)
-        credentials["use_shepherd"] = ""
-        credentials["min_shepherd_version"] = ""
+        credentials["use_shepherd"] = use_sheperd
+        credentials["min_shepherd_version"] = min_sheperd_version
     profile_line = "[" + profile + "]\n"
     new_lines = [key + "=" + value + "\n" for key, value in credentials.items()]
     new_lines.append("\n")  # Adds an empty line between two profiles.
@@ -65,12 +69,12 @@ def update_config_lines(lines, profile_title, new_lines):
     if profile_title in lines:
         profile_line_index = lines.index(profile_title)
         next_profile_index = len(lines)
-        for i in range(profile_line_index, len(lines)):
+        for i in range(profile_line_index + 1, len(lines)):
             if lines[i][0] == "[":
                 next_profile_index = i
                 break
         del lines[profile_line_index:next_profile_index]
-
-    with open(CONFIG_FILE_PATH, "a+") as configFile:
-        configFile.write(profile_title)
-        configFile.writelines(new_lines)
+    lines.append(profile_title)
+    lines += new_lines
+    with open(CONFIG_FILE_PATH, "w+") as configFile:
+        configFile.writelines(lines)

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -42,8 +42,6 @@ lines_with_profile = [
 def test_get_profile_from_creds(monkeypatch):
     test_file_name = str(uuid.uuid4()) + ".json"
     try:
-        profile = "DummyProfile"
-        creds = {"key_id": "1234", "api_key": "abc"}
         with open(test_file_name, "w+") as cred_file:
             json.dump(creds, cred_file)
 


### PR DESCRIPTION
Jira Ticket: [PXP-8581](https://ctds-planx.atlassian.net/browse/PXP-8581)

### Bug Fixes
* Replacing the existing profiles in `gen3/config` was buggy. This PR Fixes it.

### Improvements
* Added more configure arguments in order to avoid breaking changes.

