### PR TITLE
feat(indexing): add option to allow not creating a metadata column if…

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "(docs\\/_build|poetry.lock)|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-06-10T15:20:47Z",
+  "generated_at": "2022-07-01T15:56:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -380,19 +380,19 @@
       {
         "hashed_secret": "7c35c215b326b9463b669b657c1ff9873ff53d9a",
         "is_verified": false,
-        "line_number": 816,
+        "line_number": 889,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "0d515eaf06062d52e8c80abb4d3b713a65396d30",
         "is_verified": false,
-        "line_number": 820,
+        "line_number": 893,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "b4cff7c2af45cdfe66195ec574a7b8832f8621ea",
         "is_verified": false,
-        "line_number": 825,
+        "line_number": 898,
         "type": "Hex High Entropy String"
       }
     ],

--- a/gen3/cli/objects.py
+++ b/gen3/cli/objects.py
@@ -257,6 +257,13 @@ def objects_manifest_validate_format(
     default="indexing-output-manifest.csv",
     show_default=True,
 )
+@click.option(
+    "--force-metadata-columns-even-if-empty",
+    "force_metadata_columns_even_if_empty",
+    help="force the creation of a metadata column entry for a GUID even if the value "
+    "is empty. Enabling this will force the creation of metadata entries for every column.",
+    is_flag=True,
+)
 @click.pass_context
 def objects_manifest_publish(
     ctx,
@@ -285,6 +292,7 @@ def objects_manifest_publish(
         manifest_file_delimiter=manifest_file_delimiter,
         output_filename=out_manifest_file,
         submit_additional_metadata_columns=True,
+        force_metadata_columns_even_if_empty=force_metadata_columns_even_if_empty,
     )
 
 

--- a/gen3/metadata.py
+++ b/gen3/metadata.py
@@ -441,7 +441,9 @@ class Gen3Metadata:
 
         return response.json()
 
-    def _prepare_metadata(self, metadata, indexd_doc):
+    def _prepare_metadata(
+        self, metadata, indexd_doc, force_metadata_columns_even_if_empty
+    ):
         """
         Validate and generate the provided metadata for submission to the metadata
         service.
@@ -451,6 +453,7 @@ class Gen3Metadata:
         Args:
             metadata (dict): metadata provided by the submitter
             indexd_doc (dict): the indexd document created for this data
+            force_metadata_columns_even_if_empty (bool): see description in calling function
 
         Returns:
             dict: metadata ready to be submitted to the metadata service
@@ -509,6 +512,14 @@ class Gen3Metadata:
 
         if not valid:
             raise Exception(f"Metadata is not valid: {metadata}")
+
+        if not force_metadata_columns_even_if_empty:
+            # remove any empty columns if we're not being forced to include them
+            to_submit = {
+                key: value
+                for key, value in to_submit.items()
+                if value is not None and value != ""
+            }
 
         return to_submit
 

--- a/gen3/tools/indexing/index_manifest.py
+++ b/gen3/tools/indexing/index_manifest.py
@@ -120,6 +120,7 @@ def _index_record(
     replace_urls,
     thread_control,
     submit_additional_metadata_columns,
+    force_metadata_columns_even_if_empty,
     fi,
 ):
     """
@@ -131,6 +132,7 @@ def _index_record(
         replace_urls(bool): replace urls or not
         thread_num(int): number of threads for indexing
         submit_additional_metadata_columns(bool): whether to submit additional metadata to the metadata service
+        force_metadata_columns_even_if_empty (bool): see description in calling function
         fi(dict): file info
 
     Returns:
@@ -308,7 +310,11 @@ def _index_record(
                 raise Exception(
                     "Can not submit to the metadata service when using indexd basic auth"
                 )
-            metadata = mds._prepare_metadata(fi, doc)
+            metadata = mds._prepare_metadata(
+                fi,
+                doc,
+                force_metadata_columns_even_if_empty=force_metadata_columns_even_if_empty,
+            )
             if metadata:
                 mds.create(guid=doc.did, metadata=metadata, overwrite=True)
         except Exception as e:
@@ -353,6 +359,7 @@ def index_object_manifest(
     manifest_file_delimiter=None,
     output_filename="indexing-output-manifest.csv",
     submit_additional_metadata_columns=False,
+    force_metadata_columns_even_if_empty=True,
 ):
     """
     Loop through all the files in the manifest, update/create records in indexd
@@ -367,6 +374,35 @@ def index_object_manifest(
         manifest_file_delimiter(str): manifest's delimiter
         output_filename(str): output file name for manifest
         submit_additional_metadata_columns(bool): whether to submit additional metadata to the metadata service
+        force_metadata_columns_even_if_empty(bool): force the creation of a metadata column
+            entry for a GUID even if the value is empty. Enabling
+            this will force the creation of metadata entries for every column.
+            See below for an illustrative example
+
+            Example manifest_file:
+                guid, ..., columnA, columnB, ColumnC
+                   1, ...,   dataA,        ,
+                   2, ...,        ,   dataB,
+
+            Resulting metadata if force_metadata_columns_even_if_empty=True :
+                "1": {
+                    "columnA": "dataA",
+                    "columnB": "",
+                    "ColumnC": "",
+                },
+                "2": {
+                    "columnA": "",
+                    "columnB": "dataB",
+                    "ColumnC": "",
+                },
+
+            Resulting metadata if force_metadata_columns_even_if_empty=False :
+                "1": {
+                    "columnA": "dataA",
+                },
+                "2": {
+                    "columnB": "dataB",
+                },
 
     Returns:
         files(list(dict)): list of file info
@@ -435,6 +471,7 @@ def index_object_manifest(
         replace_urls,
         thread_control,
         submit_additional_metadata_columns,
+        force_metadata_columns_even_if_empty,
     )
 
     try:

--- a/gen3/tools/utils.py
+++ b/gen3/tools/utils.py
@@ -112,7 +112,9 @@ def get_and_verify_fileinfos_from_tsv_manifest(
     csv.field_size_limit(sys.maxsize)  # handle large values such as "package_contents"
     files = []
     with open(manifest_file, "r", encoding="utf-8-sig") as csvfile:
-        csvReader = csv.DictReader(csvfile, delimiter=manifest_file_delimiter)
+        csvReader = csv.DictReader(
+            csvfile, delimiter=manifest_file_delimiter, restval=""
+        )
         fieldnames = csvReader.fieldnames
         if len(fieldnames) < 2:
             logging.warning(
@@ -250,7 +252,7 @@ def get_and_verify_fileinfos_from_tsv_manifest(
             ):
                 logging.error(
                     f"ERROR: '{row[current_column_name]}' (columns names: "
-                    f"{set(output_row.keys())}) does not have required rows: "
+                    f"{set(output_row.keys())}) does not have some required rows: "
                     f"{URLS_STANDARD_KEY}, {MD5_STANDARD_KEY}, {SIZE_STANDARD_KEY}"
                 )
                 is_row_valid = False

--- a/tests/test_data/manifest_additional_metadata_mult_guids.tsv
+++ b/tests/test_data/manifest_additional_metadata_mult_guids.tsv
@@ -1,0 +1,3 @@
+guid	authz	columnA	columnB	file_name	md5	size	url	columnC
+111e396f-f1f8-11e9-9a07-0a80fada0900	['/open']	dataA		file.txt	111d83400bc1bc9dc635e334faddf33c	111	s3://my-data-bucket/dg.111/path/file.txt
+222e396f-f1f8-11e9-9a07-0a80fada0900	['/open']		dataB	file.txt	222d83400bc1bc9dc635e334faddf33c	222	s3://my-data-bucket/dg.222/path/file.txt

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -764,6 +764,79 @@ def test_index_manifest_additional_metadata(gen3_index, gen3_auth):
     assert mds_records[guid] == {"fancy_column": "fancy_data"}
 
 
+@pytest.mark.parametrize("force_metadata_columns_even_if_empty", [True, False])
+def test_index_manifest_additional_metadata_force(
+    gen3_index, gen3_auth, force_metadata_columns_even_if_empty
+):
+    """
+    When `submit_additional_metadata_columns` is set
+    the additional `force_metadata_columns_even_if_empty` results in
+    expected behavior.
+    """
+    with patch(
+        "gen3.tools.indexing.index_manifest.Gen3Metadata.create", MagicMock()
+    ) as mock_mds_create:
+        index_object_manifest(
+            manifest_file=CURRENT_DIR
+            + "/test_data/manifest_additional_metadata_mult_guids.tsv",
+            auth=gen3_auth,
+            commons_url=gen3_index.client.url,
+            thread_num=1,
+            replace_urls=False,
+            submit_additional_metadata_columns=True,
+            force_metadata_columns_even_if_empty=force_metadata_columns_even_if_empty,
+        )
+        mds_records = {
+            kwargs["guid"]: kwargs["metadata"]
+            for (_, kwargs) in mock_mds_create.call_args_list
+        }
+        assert len(mds_records) == 2
+
+    # ensure that all the records got created
+
+    indexd_records = {r["did"]: r for r in gen3_index.get_all_records()}
+    assert len(indexd_records) == 2
+
+    guid = "111e396f-f1f8-11e9-9a07-0a80fada0900"
+    assert indexd_records[guid]["file_name"] == "file.txt"
+    assert indexd_records[guid]["size"] == 111
+    assert indexd_records[guid]["hashes"] == {"md5": "111d83400bc1bc9dc635e334faddf33c"}
+    assert indexd_records[guid]["authz"] == ["/open"]
+    assert indexd_records[guid]["urls"] == ["s3://my-data-bucket/dg.111/path/file.txt"]
+    assert guid in mds_records
+
+    guid = "222e396f-f1f8-11e9-9a07-0a80fada0900"
+    assert indexd_records[guid]["file_name"] == "file.txt"
+    assert indexd_records[guid]["size"] == 222
+    assert indexd_records[guid]["hashes"] == {"md5": "222d83400bc1bc9dc635e334faddf33c"}
+    assert indexd_records[guid]["authz"] == ["/open"]
+    assert indexd_records[guid]["urls"] == ["s3://my-data-bucket/dg.222/path/file.txt"]
+    assert guid in mds_records
+
+    # ensure the metadata is formatted as expected when forced vs not
+
+    if force_metadata_columns_even_if_empty:
+        assert mds_records["111e396f-f1f8-11e9-9a07-0a80fada0900"] == {
+            "columnA": "dataA",
+            "columnB": "",
+            "columnC": "",
+        }
+
+        assert mds_records["222e396f-f1f8-11e9-9a07-0a80fada0900"] == {
+            "columnA": "",
+            "columnB": "dataB",
+            "columnC": "",
+        }
+    else:
+        assert mds_records["111e396f-f1f8-11e9-9a07-0a80fada0900"] == {
+            "columnA": "dataA",
+        }
+
+        assert mds_records["222e396f-f1f8-11e9-9a07-0a80fada0900"] == {
+            "columnB": "dataB",
+        }
+
+
 def test_index_manifest_packages(gen3_index, gen3_auth):
     """
     When `record_type == package`, packages should be created in the metadata service and any `package_contents` values should be parsed and submitted.


### PR DESCRIPTION
… there's no value in that row


### New Features
- Optional argument to indexing to allow not creating a metadata column if there's no value in that row (to support diff metadata for diff rows without ending up with a ton of empty columns in each)

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
