### PR TITLE
Fix wrap.py logs

### DIFF
--- a/gen3/tools/wrap.py
+++ b/gen3/tools/wrap.py
@@ -24,7 +24,7 @@ class Gen3Wrap:
         try:
             os.environ["GEN3_TOKEN"] = self.auth.get_access_token()
         except Gen3AuthError as e:
-            logger.error(f"ERROR getting Gen3 Access Token:", e)
+            logger.error(f"ERROR getting Gen3 Access Token: {e}")
             raise
         logger.info(
             f"Running the command {self.command_args} with gen3 access token in environment variable"
@@ -32,5 +32,5 @@ class Gen3Wrap:
         try:
             subprocess.run(cmd, stderr=subprocess.STDOUT, check=True)
         except Exception as e:
-            logger.error(f"ERROR while running '{cmd}':", e)
+            logger.error(f"ERROR while running '{cmd}': {e}")
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "gen3"
 homepage = "https://gen3.org/"
-version = "4.27.7"
+version = "4.27.8"
 description = "Gen3 CLI and Python SDK"
 authors = ["Center for Translational Data Science at the University of Chicago <support@gen3.org>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fix for this bug:
```
TypeError: not all arguments converted during string formatting
Call stack:
  [...]
  File ".../site-packages/gen3/tools/wrap.py", line 35, in run_command
    logger.error(f"ERROR while running '{cmd}':", e)
Message: "ERROR while running '[...]':"
Arguments: (CalledProcessError(1, [...]),)
```

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
